### PR TITLE
Added blockquote code to style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -55,6 +55,13 @@
 			text-decoration: none;
 		}
 
+	blockquote {
+		font-style: italic;
+		margin: 0 0 1em 15px;
+		padding-left: 10px;
+		border-left: 5px solid #ddd;
+	}
+
 	.major
 	{
 		position: relative;


### PR DESCRIPTION
I noticed the theme doesn't style quotes by default. This code will do that. Could you include this?

Screenshot:

![citaat](https://cloud.githubusercontent.com/assets/8218431/11457950/2486cbae-96b7-11e5-9ecd-2e2a4d573db9.png)

Thanks!
