### PR TITLE
Add block to enable translations posts

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -15,6 +15,13 @@
 										<ul class="tags">
 											{% if article.category %}
 											<li><a class="button" href="{{ article.category.url }}">{{ article.category|capitalize }}</a></li>
+											<!-- Add Translation Function -->
+											{% if article.translations %}
+											    {% for translation in article.translations %}
+											        <li><a href="{{ SITEURL }}/{{ translation.url }}"> <img src="{{ SITEURL }}/{{ translation.lang }}_flag.png"></a></li>
+											    {% endfor %}
+											{% endif %}
+											<!-- End Translation Function -->
 											{% endif %}
 											{% for tag in article.tags %}
 												<li><a class="button button-alt" href="{{ tag.url }}">{{ tag|capitalize }}</a></li>


### PR DESCRIPTION
Add block to enable translations posts at articles.html.
See at http://docs.getpelican.com/en/stable/content.html#translations how to add translation in your posts