### PR TITLE
Adding support to Google Analytics

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,14 @@
+{% if GOOGLE_ANALYTICS %}
+<!-- If you want to add GOOGLE_ANALYTICS tracking to your site, set at
+pelicanconf.py GOOGLE_ANALYTICS = "UA-XXXXXXX-X" -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{GOOGLE_ANALYTICS}}', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -233,5 +233,6 @@
 		<script src="/theme/js/skel.min.js"></script>
 		<script src="/theme/js/skel-panels.min.js"></script>
 		<!--[if lte IE 8]><script src="js/html5shiv.js"></script><link rel="stylesheet" href="/theme/css/ie8.css" /><![endif]-->
+		{% include 'analytics.html' %}
 	</body>
 </html>


### PR DESCRIPTION
Add analytics.html to add support to Google Analytics.
If you want to add GOOGLE ANALYTICS tracking to your site, set at pelicanconf.py `GOOGLE_ANALYTICS = "UA-XXXXXXX-X"`